### PR TITLE
Feat: Home 오늘의 최신 뉴스 & 퀴즈 데이터 API 연결 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,6 @@ yarn-error.log*
 *.sln
 *.sw*
 
+.env
+
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "lightgallery": "^2.7.0",
         "moment": "^2.30.1",
         "nouislider": "^15.6.1",
+        "openai": "^4.67.3",
         "parallax-js": "^3.1.0",
         "pinia": "^2.1.7",
         "prismjs": "^1.29.0",
@@ -2759,10 +2760,19 @@
       "version": "22.7.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.2.tgz",
       "integrity": "sha512-866lXSrpGpgyHBZUa2m9YNWqHDjjM0aBTJlNtYaGEw4rqY/dcD7deRVTbBBAJelfA7oaGDbNftXF/TL/A6RgoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/pako": {
@@ -2897,6 +2907,18 @@
       "integrity": "sha512-mJleSWbAGySd2RJdX1RBtcrUBX6snyOc0qHpgk3lGi4l9/P/3ny3ELqFWqYdkXIwwNN/kdm8nD9ky8o6l/Lx2A==",
       "license": "MIT"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2922,6 +2944,18 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -5492,6 +5526,15 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -6054,6 +6097,25 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
       }
     },
     "node_modules/formidable": {
@@ -7069,6 +7131,15 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -7933,7 +8004,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stdout": {
@@ -8013,6 +8083,45 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.18",
@@ -8200,6 +8309,47 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/openai": {
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.67.3.tgz",
+      "integrity": "sha512-HT2tZgjLgRqbLQNKmYtjdF/4TQuiBvg1oGvTDhwpSEQzxo6/oM1us8VQ53vBK2BiKvCxFuq6gKGG70qfwrNhKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.55.tgz",
+      "integrity": "sha512-zzw5Vw52205Zr/nmErSEkN5FLqXPuKX/k5d1D7RKHATGqU7y6YfX9QxZraUzUrFGqH6XzOzG196BC35ltJC4Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/opn": {
       "version": "5.3.0",
@@ -10254,6 +10404,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -10348,7 +10504,6 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -10971,6 +11126,31 @@
       "license": "MIT",
       "dependencies": {
         "kakao.maps.d.ts": "^0.1.39"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lightgallery": "^2.7.0",
     "moment": "^2.30.1",
     "nouislider": "^15.6.1",
+    "openai": "^4.67.3",
     "parallax-js": "^3.1.0",
     "pinia": "^2.1.7",
     "prismjs": "^1.29.0",

--- a/src/modules/components/home/home05/TodayLatestNewsItem.vue
+++ b/src/modules/components/home/home05/TodayLatestNewsItem.vue
@@ -1,8 +1,9 @@
 <template>
-    <a :href="item.href" class="news-link-a"> 
-        <p class="mb-3">
-            <span class="me-3">{{ item.category }}</span> {{ item.title }} 
-        </p>
+    <a :href="item.href" class="news-link-a" > 
+        <div class="mb-3 d-flex flex-row">
+            <div class="text-danger" style="min-width:70px">{{ item.category }}</div> 
+            <div class="news-title">{{ item.title }}</div>
+        </div>
     </a>
 </template>
 
@@ -20,13 +21,10 @@ const props = defineProps({
     text-decoration: none; color: #3d3d3d;
 }
 
-.news-link-a > p {
-    white-space: nowrap;  
-    overflow: hidden;    
+.news-title {
+    white-space: nowrap;
+    overflow: hidden;
     text-overflow: ellipsis;
-}
-
-.news-link-a > p > span {
-    color: var(--caution);
+    flex-grow: 1;
 }
 </style>

--- a/src/modules/components/home/home05/TodayLecture.vue
+++ b/src/modules/components/home/home05/TodayLecture.vue
@@ -7,7 +7,7 @@
                 <div class="col-md-7 mb-3 mb-md-0 h-100">     
                     <div class="h3 d-flex justify-content-center mb-5 pt-2">오늘의 간단 부동산 지식 퀴즈 🤔</div>
 
-                    <div v-for="(item, idx) in quizItems" :key="idx">
+                    <div v-for="(item, idx) in quizs" :key="idx">
                         <TodayQuizItem :item="item" :collapseId="`jobCollapse${idx}`" />
                     </div>
                 </div>
@@ -31,11 +31,14 @@
 import TodayQuizItem from './TodayQuizItem.vue';
 import TodayLatestNewsItem from './TodayLatestNewsItem.vue';
 import fetchNews from '@/utils/news.js';
+import fetchQuizs from '@/utils/quiz.js';
 import { onMounted } from 'vue';
 
 //최신 뉴스 데이터 조회
 const { items, getNewsList } = fetchNews();
-onMounted(getNewsList);
+const { quizs, getGPTResponse } = fetchQuizs();
+
+onMounted(getNewsList(), getGPTResponse());
 
 // 임시 퀴즈 데이터
 const quizItems = [

--- a/src/modules/components/home/home05/TodayLecture.vue
+++ b/src/modules/components/home/home05/TodayLecture.vue
@@ -34,32 +34,11 @@ import fetchNews from '@/utils/news.js';
 import fetchQuizs from '@/utils/quiz.js';
 import { onMounted } from 'vue';
 
-//최신 뉴스 데이터 조회
+//최신 뉴스 데이터 조회 & 퀴즈 생성 
 const { items, getNewsList } = fetchNews();
 const { quizs, getGPTResponse } = fetchQuizs();
 
 onMounted(getNewsList(), getGPTResponse());
-
-// 임시 퀴즈 데이터
-const quizItems = [
-    {
-        agenda: '전세 거래',
-        title: '전세보증금 반환을 보호하기 위한 보험은 무엇인가요?',
-        desc: '전세보증금을 보호하기 위해 전세금 반환 보증 보험에 가입할 수 있습니다.',
-        answer: '전세금 반환 보증 보험',
-        category: '부동산',
-        imgSrc: 'src/assets/images/pfp/pfp01.png'
-    },
-    {
-        agenda: '청약 제도',
-        title: '청약 신청을 하기 위해 필수적으로 가입해야 하는 통장은 무엇일까요?',
-        desc: '청약을 신청하기 위해서는 \'청약통장\'을 개설해야 합니다. 청약통장은 주택을 분양받기 위해 필요한 통장으로, 일정 금액을 납입하면서 청약 자격을 준비할 수 있습니다.',
-        answer: '청약통장',
-        category: '청약',
-        imgSrc: 'src/assets/images/pfp/pfp01.png'
-    },
-];
-
 </script>
 
 <style scoped>

--- a/src/modules/components/home/home05/TodayLecture.vue
+++ b/src/modules/components/home/home05/TodayLecture.vue
@@ -15,10 +15,9 @@
                 <!-- 뉴스 -->
                 <div class="col-md-5 mb-3 mb-md-0 h-100">
                     <div class="h3 d-flex justify-content-center mb-5 pt-2">오늘의 최신 뉴스 🔥</div>
-
                     <div class="card shadow-sm p-lg-3 mt-4 mb-lg-0">
-                        <div class="card-body p-lg-4" >
-                            <TodayLatestNewsItem v-for="(item, idx) in newsItemList" :key="idx" :item="item" />
+                        <div class="card-body p-lg-4 w-100" >
+                            <TodayLatestNewsItem v-for="(item, idx) in items" :key="idx" :item="item" />
                         </div>
                     </div>
                 </div>
@@ -31,6 +30,12 @@
 <script setup>
 import TodayQuizItem from './TodayQuizItem.vue';
 import TodayLatestNewsItem from './TodayLatestNewsItem.vue';
+import fetchNews from '@/utils/news.js';
+import { onMounted } from 'vue';
+
+//최신 뉴스 데이터 조회
+const { items, getNewsList } = fetchNews();
+onMounted(getNewsList);
 
 // 임시 퀴즈 데이터
 const quizItems = [
@@ -52,40 +57,6 @@ const quizItems = [
     },
 ];
 
-
-//임시 뉴스 데이터
-const newsItemList = [
-    {
-        href: 'https://n.news.naver.com/mnews/article/023/0003861674',
-        category: '경제',
-        title: '한발 물러선 20대… 빚으로 서울 주택 구매하는 비율 감소',
-        date: '2024.10.02',
-    },
-    {
-        href: 'https://n.news.naver.com/mnews/article/009/0005372695',
-        category: 'IT/과학',
-        title: '경제 효과 131조·일자리 55만개 창출”…구글 20년 발자취 따라가보니',
-        date: '2024.10.02',
-    },
-    {
-        href: 'https://n.news.naver.com/mnews/article/374/0000404034',
-        category: 'IT/과학',
-        title: '구글, 태국 클라우드 AI 인프라에 1조3천억 투자',
-        date: '2024.10.02',
-    },
-    {
-        href: 'https://n.news.naver.com/mnews/article/629/0000325651',
-        category: '경제',
-        title: '억대 시세 차익 \'무순위 청약\' 열풍 여전',
-        date: '2024.10.02',
-    },
-    {
-        href: 'https://n.news.naver.com/mnews/article/448/0000480489',
-        category: '경제',
-        title: '시중은행, 대출금리 또 줄줄이 인상…금리 인하기에 배불리나?',
-        date: '2024.10.02',
-    },
-]
 </script>
 
 <style scoped>

--- a/src/modules/components/home/home05/TodayQuizItem.vue
+++ b/src/modules/components/home/home05/TodayQuizItem.vue
@@ -1,15 +1,15 @@
 <template>
     <div class="card bg-secondary mb-2" :data-bs-toggle="'collapse'" :data-bs-target="`#${collapseId}`">
         <div class="card-body">
-            <div class="d-flex justify-content-between mb-2">
+            <div class="d-flex justify-content-between mb-2" :class="item.category === '부동산' ? 'far fa-building' : 'fas fa-piggy-bank'">
                 <div class="d-flex align-items-center">
-                    <img class="me-2" :src="item.imgSrc" width="24" alt="Quiz Logo">
+                    <i class="me-2" />
                     <span class="fs-sm text-dark opacity-80 ps-1">
                         <span style="color:var(--caution)">{{ item.agenda }}</span>에 관한 퀴즈입니다. 
                     </span>
                 </div>
-                <span v-if="item.category === '부동산'" class="badge bg-faded-accent rounded-pill fs-sm">{{ item.category }}</span>
-                <span v-if="item.category === '청약'" class="badge bg-faded-success rounded-pill fs-sm">{{ item.category }}</span>
+                <span v-if="item.category === '부동산'" class="badge bg-faded-accent rounded-pill fs-sm" style="margin-left:auto">{{ item.category }}</span>
+                <span v-if="item.category === '청약'" class="badge bg-faded-success rounded-pill fs-sm" style="margin-left:auto">{{ item.category }}</span>
             </div>
             <h3 class="h5 card-title pt-1 mb-0">{{ item.title }}</h3>
         </div>

--- a/src/modules/components/home/home05/TodayQuizItem.vue
+++ b/src/modules/components/home/home05/TodayQuizItem.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="card bg-secondary mb-2" :data-bs-toggle="'collapse'" :data-bs-target="`#${collapseId}`">
         <div class="card-body">
-            <div class="d-flex justify-content-between mb-2" :class="item.category === '부동산' ? 'far fa-building' : 'fas fa-piggy-bank'">
+            <div class="d-flex justify-content-between mb-2"> 
                 <div class="d-flex align-items-center">
-                    <i class="me-2" />
+                    <i class="me-2 mb-1" :class="item.category === '부동산' ? 'far fa-building' : 'fas fa-piggy-bank'"/>
                     <span class="fs-sm text-dark opacity-80 ps-1">
                         <span style="color:var(--caution)">{{ item.agenda }}</span>에 관한 퀴즈입니다. 
                     </span>

--- a/src/utils/news.js
+++ b/src/utils/news.js
@@ -31,9 +31,14 @@ const fetchNews = () => {
                 }
                 if(words.trim() === '') words = '경제';
 
+                //html태그 제거
+                const title = document.createElement('div');
+                title.innerHTML = response.data.items[i].title;
+                const cleanedTitle = title.innerText || title.textContent;
+
                 const item = {
                     category: words,
-                    title: response.data.items[i].title,
+                    title: cleanedTitle,
                     href: response.data.items[i].link,
                     date: response.data.items[i].pubDate,
                 };

--- a/src/utils/news.js
+++ b/src/utils/news.js
@@ -1,0 +1,53 @@
+import { ref } from "vue";
+import axios from "axios";
+
+const fetchNews = () => {
+    const items = ref([]);
+
+    const getNewsList = async () => {
+        items.value = [];
+
+        const URL = `/v1/search/news.json?query=${encodeURI('청약|경제|부동산')}&start=1&display=5&sort=date`;
+        const clientId = 'lG94EpCjQ7J27UoXofnQ';
+        const clientSecret = 'TxQUgnGbjp';
+
+        try {
+            const response = await axios.get(URL, {
+                headers: {
+                    Accept: "application/json",
+                    "X-Naver-Client-Id": clientId,
+                    "X-Naver-Client-Secret": clientSecret,
+                },
+            });
+
+            //카테고리 분류
+            for (let i = 0; i < Math.min(5, response.data.items.length); i++) {
+                let words = '';
+                const wordsArr = ['부동산', '청약', '아파트', '전세', '월세', '매매', '보증금', '빌라', '주택'];
+                for(let word in wordsArr) {
+                    if(response.data.items[i].title.includes(word)) {
+                        words += '부동산'; break;
+                    }
+                }
+                if(words.trim() === '') words = '경제';
+
+                const item = {
+                    category: words,
+                    title: response.data.items[i].title,
+                    href: response.data.items[i].link,
+                    date: response.data.items[i].pubDate,
+                };
+                
+                items.value.push(item);
+            }
+        } catch (err) {
+            console.error("뉴스 목록을 가져오는 데 실패했습니다:", err);
+        }
+    }
+
+    return {
+        items, getNewsList,
+    }
+};
+
+export default fetchNews;

--- a/src/utils/quiz.js
+++ b/src/utils/quiz.js
@@ -4,13 +4,24 @@ import OpenAI from 'openai'
 // chatGPT description
 const fetchQuizs = () => {
     const quizs = ref(null);
+
     const getGPTResponse = async () => {
+
+      // 세션에 저장된 퀴즈 조회
+      const storedQuizs = sessionStorage.getItem('quizs');
+
+      // 이미 퀴즈가 존재하면 중지
+      if (storedQuizs) {
+        quizs.value = JSON.parse(storedQuizs);
+        console.log("기존 퀴즈 데이터가 존재합니다.", quizs.value);
+        return;
+      } 
+
         try {
           const openai = new OpenAI({
             apiKey: `${import.meta.env.VITE_GPT_KEY}`,
             dangerouslyAllowBrowser: true,
           })
-
       
           const prompt = 
             `
@@ -32,7 +43,7 @@ const fetchQuizs = () => {
           });
 
           quizs.value = JSON.parse(response.choices[0].message.content);
-          console.log('chatGPT 결과: ', quizs.value);
+          sessionStorage.setItem('quizs', JSON.stringify(quizs.value)); //세션에 퀴즈 저장
 
         } catch (error) {
           console.log('chatGPT: 🚨 에러가 발생했습니다.', error.message);

--- a/src/utils/quiz.js
+++ b/src/utils/quiz.js
@@ -1,0 +1,44 @@
+import { ref } from 'vue';
+import OpenAI from 'openai'
+
+// chatGPT description
+const fetchQuizs = () => {
+    const quizs = ref(null);
+    const getGPTResponse = async () => {
+        try {
+          const openai = new OpenAI({
+            apiKey: `${import.meta.env.VITE_GPT_KEY}`,
+            dangerouslyAllowBrowser: true,
+          })
+
+      
+          const prompt = 
+            `
+            부동산에 관련된 간단한 퀴즈를 만들어줘.
+            형식은 아래 예시에 맞게 작성해줘. agenda는 '청약', '부동산'으로 한정해줘.
+            1문제는 부동산, 1문제는 청약에 관한 문제로 만들어줘.
+            {"agenda":"전세 거래,"title: "전세보증금 반환을 보호하기 위한 보험은 무엇인가요?","desc": "전세보증금을 보호하기 위해 전세금 반환 보증 보험에 가입할 수 있습니다.","answer": "전세금 반환 보증 보험","category": "부동산"}
+            그리고 이 두 JSON을 []배열에 넣어서 돌려줘.
+            `;
+      
+          const response = await openai.chat.completions.create({
+            messages: [
+              {
+                role: 'user',
+                content: prompt,
+              },
+            ],
+            model: 'gpt-3.5-turbo',
+          });
+
+          quizs.value = JSON.parse(response.choices[0].message.content);
+          console.log('chatGPT 결과: ', quizs.value);
+
+        } catch (error) {
+          console.log('chatGPT: 🚨 에러가 발생했습니다.', error.message);
+        }
+    }
+    return { quizs, getGPTResponse };
+}
+
+export default fetchQuizs;


### PR DESCRIPTION
## ⚒️ 작업 사항
> 주요 작업 사항 목록 입력 (이미지 첨부 가능)

<img width="1516" alt="image" src="https://github.com/user-attachments/assets/29fcc15f-bdd0-499d-8509-c33dd97f7b07">

- 오늘의 최신 뉴스 네이버 API 연결: 부동산/경제 카테고리로 분류
- 퀴즈 이미지 -> 아이콘으로 변경
- 임시 퀴즈 데이터 삭제, GPT가 부동산/청약 관련 퀴즈를 생성해 데이터를 리턴하도록 변경
- GPT 퀴즈 생성은 세션에 퀴즈 데이터가 없을 경우에만 실행하도록 제한

### 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성