### PR TITLE
Feat: 커뮤니티 글 관련 UI 일부 수정 & 댓글 기능 추가

### DIFF
--- a/src/modules/components/community/tags.js
+++ b/src/modules/components/community/tags.js
@@ -10,6 +10,13 @@ export const tagMapping = {
     'LTQS': '분양/청약 질문'
 };
 
+//태그별 뱃지 스타일
+export const matchTagStyle = (tag) => {
+    if(tag === 'REPI' || tag === 'REHT') return 'badge bg-faded-danger'
+    if(tag === 'LNQS' || tag === 'LTQS') return 'badge bg-faded-info'
+    if(tag === 'RERV' || tag === 'CTRV' || tag === 'ITRV') return 'badge bg-faded-success'
+};
+
 export const getTagName = (tag) => {
     return tagMapping[tag] || tag;
 };

--- a/src/router/community.js
+++ b/src/router/community.js
@@ -7,7 +7,12 @@ export default [
     {
         path: "/community/new",
         name: "community/new",
-        component: () => import("@/views/community/CommunityWrite.vue"),
+        component: () => import("@/views/community/CommunityForm.vue"),
+    },
+    {
+        path: "/community/:id/modify",
+        name: "community/modify",
+        component: () => import("@/views/community/CommunityForm.vue"),
     },
     {
         path: "/community/:id",

--- a/src/utils/timestamp.js
+++ b/src/utils/timestamp.js
@@ -1,12 +1,17 @@
 const formatDate = (timestamp) => {
     const date = new Date(timestamp);
-    return date.toLocaleString('ko-KR', {
+
+    // 한국 시간 (KST)로 변환
+    const offset = 9 * 60;
+    const localDate = new Date(date.getTime() + offset * 60 * 1000);
+
+    return localDate.toLocaleString('ko-KR', {
         year: 'numeric',
         month: '2-digit',
         day: '2-digit',
         hour: '2-digit',
         minute: '2-digit',
-        hour12: false
+        hour12: true,
     }).replace(',', '');
 };
 

--- a/src/views/community/ArticleEach.vue
+++ b/src/views/community/ArticleEach.vue
@@ -1,23 +1,21 @@
 <template>
     <!-- 글 태그 필터링 -->
     <tr> 
-        <td style="width:5%; text-align:center;" >{{ item.communityId }}</td>
-        <td style="width:10%; text-align:center;" >{{ getTagName(item.tag) }}</td>
-        <td style="width:50%; text-align:center;">
-            <router-link :to="{ path: `/community/${item.communityId}` }" style="text-decoration: none; color:var(--grayTitle)">{{ item.title }}</router-link>
+        <td style="width:3%; text-align: center;" >{{ item.communityId }}</td>
+        <!-- <td style="width:10%; " >{{ getTagName(item.tag) }}</td> -->
+        <td style="width:5%;"> <span :class="matchTagStyle(item.tag)">{{ getTagName(item.tag) }}</span> </td>
+        <td style="width:62%;">
+            <router-link :to="{ path: `/community/${item.communityId}` }" style="text-decoration: none; color:var(--grayTitle)" >{{ item.title }}</router-link>
         </td>
-        <td class="truncate" style="text-align:center;">{{ item.nickname }}</td>
-        <td style="width:10%; text-align:center;"> {{ new Date(item.createdAt).toISOString().slice(0, 10) }}</td>
-        <td style="width:15%; text-align:center;">{{ item.views }}</td>
+        <td class="truncate" style="width:10%; text-align: center;">{{ item.nickname }}</td>
+        <td style="width:10%; text-align: center;"> {{ new Date(item.createdAt).toISOString().slice(0, 10) }}</td>
+        <td style="width:10%; text-align: center;">{{ item.views }}</td>
     </tr>                                                                                                                                                                                   
 </template>
 
 <script setup>
 import { ref } from 'vue';
-import { getTagName } from '@/modules/components/community/tags.js';
-
-const iconClass = ref("far fa-heart");
-
+import { getTagName, matchTagStyle } from '@/modules/components/community/tags.js';
 const props = defineProps({
     item: {
         type: Object,

--- a/src/views/community/Comment.vue
+++ b/src/views/community/Comment.vue
@@ -15,13 +15,18 @@
               <h6 class="mb-0"> {{ cmt.memberName }}</h6>
               <span class="fs-sm text-muted"> {{ formatDate(cmt.createdAt) }}</span>
             </div>
+
           </div>
-          <p class="pb-2 mb-0 command-text-container">
-            {{ cmt.content }}
-            <button type="button" class="btn btn-outline-danger btn-icon delete-btn-continer" @click="deleteComment(cmt.cmtId)" style="justify-content: center;">
-              <i class="fa fa-trash"></i>
+
+          <p> {{ cmt.content }} </p>
+          <div class="w-100 d-flex justify-content-end gap-2" >
+            <button class="btn btn-secondary btn-icon">
+              <i class="fa-regular fa-pen-to-square"></i>
             </button>
-          </p>
+            <button class="btn btn-outline-danger btn-icon" @click="deleteComment(cmt.cmtId)" style="justify-content: center;">
+              <i class="fa-solid fa-trash-can"></i>
+            </button>
+          </div>
 
         </div>
       </div>
@@ -124,5 +129,4 @@
     justify-content: space-between;
     align-items: center;
   }
-
   </style>

--- a/src/views/community/Comment.vue
+++ b/src/views/community/Comment.vue
@@ -12,13 +12,13 @@
               alt="Comment author"
             />
             <div class="ps-3">
-              <h6 class="mb-0">우산을 쓴 커비</h6>
-              <span class="fs-sm text-muted">2024-09-27</span>
+              <h6 class="mb-0"> {{ cmt.memberName }}</h6>
+              <span class="fs-sm text-muted"> {{ formatDate(cmt.createdAt) }}</span>
             </div>
           </div>
           <p class="pb-2 mb-0 command-text-container">
-            안녕하세요. 댓글입니다요~
-            <button type="button" class="btn btn-outline-danger btn-icon delete-btn-continer" @click="deleteComment" style="justify-content: center;">
+            {{ cmt.content }}
+            <button type="button" class="btn btn-outline-danger btn-icon delete-btn-continer" @click="deleteComment(cmt.cmtId)" style="justify-content: center;">
               <i class="fa fa-trash"></i>
             </button>
           </p>
@@ -30,9 +30,28 @@
   
   <script setup>
   import { onMounted } from 'vue';
+  import { useRoute } from 'vue-router';
+  import { formatDate } from '@/utils/timestamp.js';
+  import axios from 'axios';
+
+  const route = useRoute();
+  const emit = defineEmits(['deleteComment']);
   
-  const deleteComment = () => {
-    console.log('Comment deleted');
+  const deleteComment = async (cmtId) => {
+    if(!confirm('댓글을 삭제하시겠습니까?')) return;
+
+    try {
+      const res = await axios.delete(`/api/community/${route.params.id}/comments`, {
+        params: { cmtId: cmtId }
+      });
+
+      if(res.status === 200) {
+        emit('deleteComment', cmtId);
+      }
+      
+    } catch (err) {
+      alert('댓글 삭제에 실패했습니다 😵‍💫');
+    }
   };
   
   onMounted(() => {
@@ -44,6 +63,13 @@
       }, 1500);
     }
   });
+
+  const props = defineProps({
+    cmt: {
+      type: Object,
+      required: true,
+    },
+  })
   </script>
   
   <style scoped>

--- a/src/views/community/Comment.vue
+++ b/src/views/community/Comment.vue
@@ -19,7 +19,9 @@
           </div>
 
           <p> {{ cmt.content }} </p>
-          <div class="w-100 d-flex justify-content-end gap-2" >
+          <div 
+            v-if="isLogin && cmt.memberId === id"
+            class="w-100 d-flex justify-content-end gap-2" >
             <button class="btn btn-secondary btn-icon">
               <i class="fa-regular fa-pen-to-square"></i>
             </button>
@@ -37,9 +39,11 @@
   import { onMounted } from 'vue';
   import { useRoute } from 'vue-router';
   import { formatDate } from '@/utils/timestamp.js';
+  import { useAuthStore } from '@/stores/auth';
   import axios from 'axios';
 
   const route = useRoute();
+  const { isLogin, id } = useAuthStore();
   const emit = defineEmits(['deleteComment']);
   
   const deleteComment = async (cmtId) => {

--- a/src/views/community/CommunityDetail.vue
+++ b/src/views/community/CommunityDetail.vue
@@ -9,11 +9,14 @@
         
             <!-- 게시글 작성자 및 작성 시간 -->
             <div class="d-flex justify-content-between gap-5">
-                <p style="color:var(--gray1)">
+                <p style="color:var(--gray1)" class="w-25">
                     <i class="fa-solid fa-user me-2"></i>
                     {{ post.nickname }}
                 </p>
-                <p style="color:var(--gray1)">{{ formatDate(post.createdAt) }}</p>
+                <div class="w-25 d-flex justify-content-end gap-3">
+                    <p style="color:var(--gray1)">조회수: {{ post.views }}</p>
+                    <p style="color:var(--gray1)">{{ formatDate(post.createdAt) }}</p>
+                </div>
             </div>
         
             <hr>

--- a/src/views/community/CommunityDetail.vue
+++ b/src/views/community/CommunityDetail.vue
@@ -126,6 +126,10 @@ const postComment = async (communityId) => {
       alert('댓글을 작성하려면 로그인해주세요.'); return;
     }
 
+    if(cmtContent.value === null || cmtContent.value.trim() === '') {
+        alert('댓글 내용을 입력해주세요.'); return;
+    }
+
     const comment = {
         communityId: communityId,
         memberId: id,

--- a/src/views/community/CommunityDetail.vue
+++ b/src/views/community/CommunityDetail.vue
@@ -28,7 +28,7 @@
                 <i class="fa-solid fa-list"></i> 목록
             </button>
             <!-- 수정, 삭제 버튼 -->
-            <button v-if="id !== null && id === post.memberId" class="btn btn-primary me-2">
+            <button v-if="id !== null && id === post.memberId" class="btn btn-primary me-2" @click="goToModifyPage">
                 <i class="fa-regular fa-pen-to-square"></i> 수정
             </button>
             <button v-if="id !== null && id === post.memberId" class="btn btn-danger" @click="deleteCommunity">
@@ -130,6 +130,14 @@ const router = useRouter(); // router 인스턴스를 가져옵니다.
 const goToMainPage = () => {
   router.push('/community'); // /communitymain 경로로 이동합니다.
 };
+const goToModifyPage = () => {
+    localStorage.setItem('title', post.value.title);
+    localStorage.setItem('content', post.value.content);
+    localStorage.setItem('tag', post.value.tag);
+    localStorage.setItem('pics', post.value.pics);
+    
+    router.push(`/community/${route.params.id}/modify`);
+}
 
 // 페이지네이션 정보
 const currentPage = ref(1); // 현재 게시글 페이지

--- a/src/views/community/CommunityDetail.vue
+++ b/src/views/community/CommunityDetail.vue
@@ -42,11 +42,11 @@
             <div class="row mt-2">
                 <div class="col-11">
                     <label class="form-label">댓글</label>
-                    <input type="text" class="form-control" placeholder="내용을 입력하세요.">
+                    <input type="text" class="form-control" placeholder="내용을 입력하세요." v-model="cmtContent">
                 </div>
                 <div class="col-1">
                     <label class="form-label">&nbsp;</label>
-                    <button class="form-control btn btn-primary">작성</button>
+                    <button class="form-control btn btn-primary" @click="postComment(post.communityId)">작성</button>
                 </div>
             </div>
         
@@ -103,6 +103,8 @@ const fetchDetail = async () => {
     } catch (err) {
         console.error('>> 상세글 조회 실패 (T>T) ', err.message);
     }
+
+    console.log('Logged-in user ID:', id);
 }
 onMounted(fetchDetail);
 
@@ -113,6 +115,27 @@ const deleteCommunity = async () => {
 
     } catch (err) {
         console.error('>> 커뮤니티 삭제 실패 (T>T) ', err.message);
+    }
+}
+
+//댓글 작성
+const cmtContent = ref(null);
+const postComment = async (communityId) => {
+    const comment = {
+        communityId: communityId,
+        memberId: id,
+        content: cmtContent.value,
+    }
+
+    try {
+        const res = await axios.post(`/api/community/${route.params.id}/comments`, comment);
+
+        if(res.status === 200) {
+            post.value.comments.push(res.data);
+            cmtContent.value = null; //댓글 작성 후 입력창 초기화
+        }
+    } catch (err) {
+        console.error('>> 댓글 작성 실패 (T>T) ', err.message);
     }
 }
 

--- a/src/views/community/CommunityDetail.vue
+++ b/src/views/community/CommunityDetail.vue
@@ -51,7 +51,9 @@
             </div>
         
             <!-- 댓글 목록 -->
-            <Comment v-for="cmt in post.comments" :key="cmt.cmtId" :cmt="cmt" @deleteComment="handleDeleteComment"/>
+            <Comment v-for="cmt in post.comments" :key="cmt.cmtId" :cmt="cmt" 
+                @deleteComment="handleDeleteComment"
+                @updateComment="handleUpdateComment" />
 
         </div>
     </div>
@@ -146,6 +148,14 @@ const postComment = async (communityId) => {
 // 댓글 삭제 시 호출
 const handleDeleteComment = (cmtId) => {
   post.value.comments = post.value.comments.filter(cmt => cmt.cmtId !== cmtId);
+};
+
+// 댓글 수정 시 호출
+const handleUpdateComment = (updatedComment) => {
+  const index = post.value.comments.findIndex(cmt => cmt.cmtId === updatedComment.cmtId);
+  if (index !== -1) {
+    post.value.comments[index] = updatedComment;  // 수정된 댓글로 교체
+  }
 };
 
 const router = useRouter(); // router 인스턴스를 가져옵니다.

--- a/src/views/community/CommunityDetail.vue
+++ b/src/views/community/CommunityDetail.vue
@@ -99,12 +99,12 @@ const fetchDetail = async () => {
 
         if(res.status === 200) {
             post.value = res.data;
+
+            if(post.value.comments === null) post.value.comments = [];
         }   
     } catch (err) {
         console.error('>> 상세글 조회 실패 (T>T) ', err.message);
     }
-
-    console.log('Logged-in user ID:', id);
 }
 onMounted(fetchDetail);
 
@@ -132,6 +132,7 @@ const postComment = async (communityId) => {
 
         if(res.status === 200) {
             post.value.comments.push(res.data);
+
             cmtContent.value = null; //댓글 작성 후 입력창 초기화
         }
     } catch (err) {
@@ -156,13 +157,4 @@ const goToModifyPage = () => {
     
     router.push(`/community/${route.params.id}/modify`);
 }
-
-// 페이지네이션 정보
-const currentPage = ref(1); // 현재 게시글 페이지
-const totalPages = 10; // 전체 게시글 페이지 수
-
-// 페이지 변경 처리
-const handlePageChange = (page) => {
-    currentPage.value = page;
-};
 </script>

--- a/src/views/community/CommunityDetail.vue
+++ b/src/views/community/CommunityDetail.vue
@@ -14,7 +14,7 @@
                     {{ post.nickname }}
                 </p>
                 <div class="w-25 d-flex justify-content-end gap-3">
-                    <p style="color:var(--gray1)">조회수: {{ post.views }}</p>
+                    <p style="color:var(--gray1)"><i class="far fa-eye"/> <span style="font-weight:bold">{{ post.views }}</span></p>
                     <p style="color:var(--gray1)">{{ formatDate(post.createdAt) }}</p>
                 </div>
             </div>
@@ -39,12 +39,12 @@
             </div>
     
             <!-- 댓글 입력 -->
-            <div class="row mt-2">
-                <div class="col-11">
+            <div class="d-flex w-100 mt-2 justify-content-between">
+                <div style="width:84%">
                     <label class="form-label">댓글</label>
                     <input type="text" class="form-control" placeholder="내용을 입력하세요." v-model="cmtContent">
                 </div>
-                <div class="col-1">
+                <div style="width:15%">
                     <label class="form-label">&nbsp;</label>
                     <button class="form-control btn btn-primary" @click="postComment(post.communityId)">작성</button>
                 </div>
@@ -79,7 +79,6 @@
 <script setup>
 import { useRouter, useRoute } from 'vue-router'; // Vue Router를 불러옵니다.
 import Comment from '@/views/community/Comment.vue';
-import Pagination from '@/common/components/Pagination.vue'; // Pagination 컴포넌트 경로 수정 필요
 
 import axios from 'axios';
 import { onMounted, ref } from 'vue'; // ref를 vue에서 임포트합니다.

--- a/src/views/community/CommunityDetail.vue
+++ b/src/views/community/CommunityDetail.vue
@@ -86,7 +86,7 @@ import { formatDate } from '@/utils/timestamp.js';
 import { getTagName, matchTagStyle } from '@/modules/components/community/tags.js';
 
 import { useAuthStore } from '@/stores/auth';
-const { id } = useAuthStore(); //현재 로그인한 아이디
+const { isLogin, id } = useAuthStore(); //현재 로그인한 아이디
 
 //상세글 데이터 조회
 const route = useRoute();
@@ -120,6 +120,10 @@ const deleteCommunity = async () => {
 //댓글 작성
 const cmtContent = ref(null);
 const postComment = async (communityId) => {
+    if(!isLogin) {
+      alert('댓글을 작성하려면 로그인해주세요.'); return;
+    }
+
     const comment = {
         communityId: communityId,
         memberId: id,

--- a/src/views/community/CommunityDetail.vue
+++ b/src/views/community/CommunityDetail.vue
@@ -1,66 +1,64 @@
 <template>
-    <div class="outer-container">
-        <br><br><br>
-        <div class="container">
-        <!-- 게시글 제목 -->
-        <h1 style="margin-top:30px;">{{ post.title }}</h1>
-    
-        <!-- 게시글 작성자 및 작성 시간 -->
-        <div class="my-3 d-flex justify-content-between">
-            <div>
-                <i class="fa-solid fa-user" style="margin-top:30px;"></i>
-                {{ post.nickname }}
-            </div>
-            <div>
-                <i class="fa-regular fa-clock"></i>
-                {{ formatDate(post.createdAt) }}
-            </div>
-        </div>
-    
-        <hr />  
-    
-        <!-- 게시글 내용 -->
-        <div class="content" v-html="post.content"></div>
-    
-        <!-- 목록 및 수정, 삭제 버튼 -->
-        <div class="my-5">
-            <button class="btn btn-primary me-2" @click="goToMainPage">
-                <i class="fa-solid fa-list"></i> 목록
-            </button>
-            <!-- 수정, 삭제 버튼 -->
-            <button v-if="id !== null && id === post.memberId" class="btn btn-primary me-2" @click="goToModifyPage">
-                <i class="fa-regular fa-pen-to-square"></i> 수정
-            </button>
-            <button v-if="id !== null && id === post.memberId" class="btn btn-danger" @click="deleteCommunity">
-                <i class="fa-solid fa-trash-can"></i> 삭제
-            </button>
-        </div>
-    
-        <!-- 댓글 입력 -->
-        <div class="row mt-2">
-            <div class="col-11">
-                <label class="form-label">댓글</label>
-                <input type="text" class="form-control" placeholder="내용을 입력하세요.">
-            </div>
-            <div class="col-1">
-                <label class="form-label">&nbsp;</label>
-                <button class="form-control btn btn-primary">작성</button>
-            </div>
-        </div>
-    
-        <!-- 댓글 목록 -->
-        <Comment></Comment>
-        <Comment></Comment>
-        <Comment></Comment>
-        <Comment></Comment>
+    <div class="outer-container py-5">
+        <div class="container py-5 px-5 rounded box-shadow">
+            <!-- 게시글 제목 -->
+             <div class="w-100 mb-5">
+                <span class="mb-3" :class="matchTagStyle(post.tag)" style="padding:1% 1.5%; font-size: 1rem">{{ getTagName(post.tag) }}</span> 
+                <h1 class="h2" style="color: var(--grayTitle)">{{ post.title }}</h1>
+             </div>
         
-        <!-- 페이지네이션 -->
-        <div class="con-paging">
-            <Pagination :currentPage="currentPage" :totalPages="totalPages" @update:page="handlePageChange" />
-        </div>
+            <!-- 게시글 작성자 및 작성 시간 -->
+            <div class="d-flex justify-content-between gap-5">
+                <p style="color:var(--gray1)">
+                    <i class="fa-solid fa-user me-2"></i>
+                    {{ post.nickname }}
+                </p>
+                <p style="color:var(--gray1)">{{ formatDate(post.createdAt) }}</p>
+            </div>
+        
+            <hr>
+
+            <!-- 게시글 내용 -->
+            <div class="content my-5 fs-lg" v-html="post.content"></div>
+        
+            <!-- 목록 및 수정, 삭제 버튼 -->
+            <div class="d-flex justify-content-end my-5">
+                <button class="btn btn-light-primary btn-icon shadow-sm me-2" @click="goToMainPage">
+                    <i class="fa-solid fa-list"></i>
+                </button>
+                <!-- 수정, 삭제 버튼 -->
+                <button v-if="id !== null && id === post.memberId" class="btn btn-secondary btn-icon me-2" @click="goToModifyPage">
+                    <i class="fa-regular fa-pen-to-square"></i>
+                </button>
+                <button v-if="id !== null && id === post.memberId" class="btn btn-outline-danger btn-icon" @click="deleteCommunity">
+                    <i class="fa-solid fa-trash-can"></i>
+                </button>
+            </div>
+    
+            <!-- 댓글 입력 -->
+            <div class="row mt-2">
+                <div class="col-11">
+                    <label class="form-label">댓글</label>
+                    <input type="text" class="form-control" placeholder="내용을 입력하세요.">
+                </div>
+                <div class="col-1">
+                    <label class="form-label">&nbsp;</label>
+                    <button class="form-control btn btn-primary">작성</button>
+                </div>
+            </div>
+        
+            <!-- 댓글 목록 -->
+            <Comment></Comment>
+            <Comment></Comment>
+            <Comment></Comment>
+            <Comment></Comment>
+            
+            <!-- 페이지네이션 -->
+            <div class="con-paging">
+                <Pagination :currentPage="currentPage" :totalPages="totalPages" @update:page="handlePageChange" />
+            </div>
 
         </div>
-        <br><br><br>
     </div>
 </template>
 
@@ -77,9 +75,6 @@
 }
 .container {
     background-color:white;
-    border: 1px solid #ccc; /* 테두리 색상 및 두께 설정 */
-    border-radius: 15px;    /* 둥글게 만들기, 값은 원하는 대로 조절 가능 */
-    padding: 50px;          /* 테두리 안쪽에 여백을 추가 */
 }
 .con-paging {
     width:100%; height:100px; display:flex; justify-content: center; align-items: end;
@@ -94,6 +89,7 @@ import Pagination from '@/common/components/Pagination.vue'; // Pagination 컴�
 import axios from 'axios';
 import { onMounted, ref } from 'vue'; // ref를 vue에서 임포트합니다.
 import { formatDate } from '@/utils/timestamp.js';
+import { getTagName, matchTagStyle } from '@/modules/components/community/tags.js';
 
 import { useAuthStore } from '@/stores/auth';
 const { id } = useAuthStore(); //현재 로그인한 아이디

--- a/src/views/community/CommunityDetail.vue
+++ b/src/views/community/CommunityDetail.vue
@@ -51,15 +51,7 @@
             </div>
         
             <!-- 댓글 목록 -->
-            <Comment></Comment>
-            <Comment></Comment>
-            <Comment></Comment>
-            <Comment></Comment>
-            
-            <!-- 페이지네이션 -->
-            <div class="con-paging">
-                <Pagination :currentPage="currentPage" :totalPages="totalPages" @update:page="handlePageChange" />
-            </div>
+            <Comment v-for="cmt in post.comments" :key="cmt.cmtId" :cmt="cmt" @deleteComment="handleDeleteComment"/>
 
         </div>
     </div>
@@ -124,6 +116,10 @@ const deleteCommunity = async () => {
     }
 }
 
+// 댓글 삭제 시 호출
+const handleDeleteComment = (cmtId) => {
+  post.value.comments = post.value.comments.filter(cmt => cmt.cmtId !== cmtId);
+};
 
 const router = useRouter(); // router 인스턴스를 가져옵니다.
 const goToMainPage = () => {

--- a/src/views/community/CommunityForm.vue
+++ b/src/views/community/CommunityForm.vue
@@ -122,6 +122,7 @@ const submitCommunity = async () => {
     //성공 후 상세 페이지로 이동
     if(res.status === 200) {
       router.push(`/community/${res.data}`);
+      removeBindingContents(); //성공 후 바인딩된 데이터 제거
     } 
   } catch (err) {
     console.error('>> 작성 실패 (T o T) 에러:', err.message);
@@ -200,6 +201,13 @@ const bindOriginalContents = () => {
   selectedType.value = localStorage.getItem('tag');
   pics.value = localStorage.getItem('pics');
   $('#summernote').summernote('code', localStorage.getItem('content'));
+}
+
+const removeBindingContents = () => {
+  localStorage.removeItem('title');
+  localStorage.removeItem('tag');
+  localStorage.removeItem('pics');
+  localStorage.removeItem('content');
 }
 
 const goBack = () => {

--- a/src/views/community/CommunitySearch.vue
+++ b/src/views/community/CommunitySearch.vue
@@ -2,7 +2,7 @@
     <div class="container mt-5">
         <h3 class="mb-3" style="color:var(--grayTitle)">커뮤니티</h3>
         <div class="dictionary-container card card-body border-0 shadow-sm p-5 mt-4 pt-5">
-            <form class="form-group">
+            <form class="form-group"  @submit.prevent="filterList">
                 <!-- 분류 Dropdown -->
                 <div class="dropdown w-sm-25 border-end-md" data-bs-toggle="select">
                     <button class="btn btn-link" type="button" data-bs-toggle="dropdown">
@@ -24,7 +24,8 @@
                     <span class="input-group-text">
                         <i class="fas fa-search"></i>
                     </span>
-                    <input type="text" class="form-control" placeholder="공고 제목을 입력하세요" v-model="searchTitle">
+                    <input type="text" class="form-control" placeholder="공고 제목을 입력하세요" v-model="searchTitle"
+                    @keyup.enter="filterList">
                 </div>
                 <button type="button" class="btn btn-translucent-primary w-25" @click="filterList">검색</button>
             </form>

--- a/src/views/community/CommunitySearch.vue
+++ b/src/views/community/CommunitySearch.vue
@@ -32,7 +32,7 @@
             <!-- 게시글 건수, 조회 방식 select-->
             <div class="selector d-flex w-100 justify-content-end gap-2 mt-3">
                 <!-- 게시글 수와 페이지 수 조회 -->
-                <div style="margin-right:auto; margin-top:auto">
+                <div style="margin-right:auto; margin-top:auto; min-width:100px">
                     전체 <span class="text-primary fw-bolder">{{ filteredList.length }}</span> 건 <span class="text-primary fw-bolder">{{ currentPage }}</span>/ {{ totalPages }} 페이지
                 </div>
 

--- a/src/views/community/CommunitySearch.vue
+++ b/src/views/community/CommunitySearch.vue
@@ -98,8 +98,8 @@
                 </table>
             </div>
             
-            <!-- 글쓰기 버튼 -->
-            <div class="w-100 d-flex">
+            <!-- 글쓰기 버튼: 로그인했을 경우에만 노출 -->
+            <div v-if="authStore.isLogin" class="w-100 d-flex">
                 <button type="button" class="btn btn-outline-primary ms-auto" style="width:120px" @click="goToWritePage">글쓰기</button>
             </div>
             
@@ -116,8 +116,10 @@ import axios from 'axios';
 import { ref, onMounted, getTransitionRawChildren } from 'vue';
 import ArticleEach from './ArticleEach.vue';
 import Pagination from '@/common/components/Pagination.vue';
+import { useAuthStore } from '@/stores/auth';
 import { getTagName, tagMapping } from '@/modules/components/community/tags.js';
 
+const authStore = useAuthStore();
 
 const selectedOwner = ref('ALL'); // 드롭다운에서 선택한 값을 저장하는 상태
 const searchTitle = ref(''); //검색어

--- a/src/views/community/CommunityWrite.vue
+++ b/src/views/community/CommunityWrite.vue
@@ -1,10 +1,8 @@
 <template> 
   <div class="outer-background">
-    <div class="container">
-      <br><br>
-      <div class="write-form">
-        <h2>게시글 작성</h2>
-        <br><br>
+    <div class="container pt-5 pb-5">
+      <div class="write-form pt-5 px-5 pb-5 rounded">
+        <h2 class="mb-5">게시글 작성</h2>
         <form>
           <div class="mb-3">
             <!-- 제목 -->
@@ -21,10 +19,10 @@
         </form>
 
         <!-- 정보제공/후기 -->
-        <div class="subject-choose-container">
+        <div class="w-100 d-flex gap-5">
           <div class="out-choose-info">
             <label for="info" class="choose-label">정보제공</label>
-            <div class="in-choose-info">
+            <div class="in-choose-info gap-3">
               <button :class="{ active: selectedType === 'REPI' }" @click="selectType('REPI')">부동산 정책/투자</button>
               <button class="policy-issue" :class="{ active: selectedType === 'REHT' }" @click="selectType('REHT')">부동산 핫이슈</button>
             </div>
@@ -33,7 +31,7 @@
           <!-- 후기 -->
           <div class="out-choose-info">
             <label for="info" class="choose-label">후기</label>
-            <div class="in-choose-info">
+            <div class="in-choose-info gap-3" >
               <button class="review" :class="{ active: selectedType === 'RERV' }" @click="selectType('RERV')">부동산 후기</button>
               <button class="contract-review" :class="{ active: selectedType === 'CTRV' }" @click="selectType('CTRV')">계약/입주 후기</button>
               <button class="interior-review" :class="{ active: selectedType === 'ITRV' }" @click="selectType('ITRV')">인테리어 후기</button>
@@ -43,7 +41,7 @@
           <!-- 질문 -->
           <div class="out-choose-info">
             <label for="info" class="choose-label">질문</label>
-              <div class="in-choose-info">
+              <div class="in-choose-info gap-3">
                 <button class="loan-question" :class="{ active: selectedType === 'LNQS' }" @click="selectType('LNQS')">대출 질문</button>
                 <button :class="{ active: selectedType === 'LTQS' }" @click="selectType('LTQS')">분양/청약 질문</button>
               </div>
@@ -51,11 +49,11 @@
         </div>
   
         <!-- summernote -->
-        <div class="summernote-container">
+        <div class="summernote-container mt-4">
           <div id="summernote"></div>
         </div>
         
-        <div class="bottom-button-container mt-4">
+        <div class="bottom-button-container mt-4 gap-3">
           <!-- 취소 버튼 (왼쪽) -->
           <button type="button" class="btn btn-primary" style="background-color:#A9A9A9;" @click="goToCommunityMainPage">취소</button>
           <!-- 등록 버튼 (오른쪽) --> 
@@ -152,7 +150,7 @@ onMounted(() => {
     placeholder: '본문 내용을 입력해주세요.',
     tabsize: 2,
     height: 500,
-    width:1150,
+    width: '100%',
     lang: 'ko-KR',
     
     toolbar: [
@@ -205,30 +203,8 @@ button { /* 일반적인 버튼 */
   transition: background-color 0.3s;
 }
 
-/* 각 버튼 사이 간격 조정 */
-.policy-issue {
-  margin-left: 15px; /* 부동산 정책/투자와 부동산 핫이슈 사이 15px */
-}
-
-.contract-review {
-  margin-left: 15px; /* 부동산 후기와 계약/입주 후기 사이 15px */
-}
-
-.interior-review {
-  margin-left: 15px; /* 계약/입주 후기와 인테리어 후기 사이 15px */
-}
-
-/* 기본 마진 설정 */
-button + button {
-  margin-left: 15px;
-}
-
-.out-choose-info {
-  margin-left : 35px;
-}
 .in-choose-info {
   display:flex;
-  margin-top: 8px;
 }
 
 .out-choose-info button:hover,
@@ -246,41 +222,26 @@ button + button {
   font-size: 1.225rem;
   font-weight: bold;
 }
-
 .outer-background {
   background-color: #E6E6FA; /* 보라색 */
-  padding: 20px; /* 여백 추가 */
 }
 /* write-form은 흰색 배경으로 설정 */
 .write-form {
   background-color: white; /* 흰색 배경 */
-  padding: 20px; /* 내부 여백 */
-  border-radius: 8px; /* 모서리를 둥글게 */
 }
 /* summernote - 자동으로 display:flex 적용 */
 .summernote-container {
   display: flex;
   justify-content: center;  /* 가로 가운데 정렬 */
-  margin-top:50px; 
-  margin-left:35px;
-}
-.write-form {
-  padding:50px;
-}
-/* 제목 */
-.mb-3 {
-  margin-left: 35px;
 }
 /* 주제 선택 */
 .select-subject {
   display:flex;
   flex-direction:column; /* 정렬 방식이 세로 */
-  margin-left: 35px;
 }
 /* 취소 + 선택 버튼 */
 .bottom-button-container {
   display:flex;
   justify-content: flex-end;
-  margin-right:15px;
 }
 </style>


### PR DESCRIPTION
## ⚒️ 작업 사항
> 주요 작업 사항 목록 입력 (이미지 첨부 가능)

- 커뮤니티 메인 글목록 UI 수정(태그 뱃지 설정/레이아웃...) & 상세글 조회수 카운트 추가
<img width="1545" alt="image" src="https://github.com/user-attachments/assets/cadfa1d8-863a-4a0e-98d1-4a92ce84a46b">

<br/>

- 커뮤니티 글 수정 + 글 작성 폼 공유하도록 수정
<img width="689" alt="image" src="https://github.com/user-attachments/assets/31251cd8-52f5-4964-85b4-a3c9b0b84696">
<img width="742" alt="image" src="https://github.com/user-attachments/assets/336a2763-5e7b-45fa-86f7-59e46d0400bd">



<br/>
- 커뮤니티 상세글 태그 표시 추가 & UI 수정... & 데이터 바인딩 완료 & 로그인한 유저 제한 & 유효성 검사 추가 <br/>
- 커뮤니티 댓글 조회/작성/수정/삭제 & 유효성 검사 & 로그인한 유저 제한 & 댓글 작성자 == 로그인 유저 제한 추가
<img width="1178" alt="image" src="https://github.com/user-attachments/assets/09fb5a0a-f3a5-4bcb-9266-d70a50223483">
<img width="764" alt="image" src="https://github.com/user-attachments/assets/3bc1acfe-fc27-4e8c-923f-bd55d305fd8a">
<br/>

- 댓글 수정 버튼 클릭시 input태그로 변환되고 표시 버튼 변경
<img width="1093" alt="image" src="https://github.com/user-attachments/assets/bccd9ad1-d09f-42cb-8d7a-09d20da344f9">

🔖 사용자 프로필 사진 처리 필요